### PR TITLE
Read direct chunk buffer

### DIFF
--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -583,16 +583,14 @@ cdef class DatasetID(ObjectID):
                     ret = data[:read_chunk_nbytes]  # this copies ?!
             finally:
                 efree(offset)
-                if data and out is None:
+                if out is not None:
+                    PyBuffer_Release(&view)
+                elif data:
                     efree(data)
                 if space_id:
                     H5Sclose(space_id)
-                if out is not None:
-                    PyBuffer_Release(&view)
-            if out is None:
-                return filters, ret
-            else:
-                return filters, read_chunk_nbytes
+
+            return filters, ret if out is None else read_chunk_nbytes
 
     IF HDF5_VERSION >= (1, 10, 5):
 

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -572,7 +572,7 @@ cdef class DatasetID(ObjectID):
                 else:
                     PyObject_GetBuffer(out, &view, PyBUF_ANY_CONTIGUOUS)
                     if view.len < read_chunk_nbytes:
-                        raise TypeError("out is not large enough (%d, require %d)" % (view.len, read_chunk_nbytes))
+                        raise ValueError("out is not large enough (%d, require %d)" % (view.len, read_chunk_nbytes))
                     data = <char *>view.buf
 
                 IF HDF5_VERSION >= (1, 10, 3):

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -32,6 +32,9 @@ from cpython cimport PyObject_GetBuffer, \
                      PyBuffer_Release
 
 
+# Python imports
+import numpy as np
+
 # Initialization
 import_array()
 
@@ -535,8 +538,9 @@ cdef class DatasetID(ObjectID):
               which are the raw data storing this chunk.
 
             if an output buffer is provided:
-              Returns a tuple containing the `filter_mask` and a memoryview on
-              the used area of the output buffer.
+              Returns a tuple containing the `filter_mask` and a numpy array
+              of the read raw data. This array shares the memory of the out
+              argument buffer.
 
             `filter_mask` is a bit field of up to 32 values. It records which
             filters have been applied to this chunk, of the filter pipeline
@@ -595,7 +599,7 @@ cdef class DatasetID(ObjectID):
                 if space_id:
                     H5Sclose(space_id)
 
-            return filters, ret if out is None else out[:read_chunk_nbytes]
+            return filters, ret if out is None else np.asarray(out[:read_chunk_nbytes])
 
     IF HDF5_VERSION >= (1, 10, 5):
 

--- a/h5py/h5d.pyx
+++ b/h5py/h5d.pyx
@@ -28,6 +28,7 @@ from ._proxy cimport dset_rw
 from ._objects import phil, with_phil
 from cpython cimport PyObject_GetBuffer, \
                      PyBUF_ANY_CONTIGUOUS, \
+                     PyBUF_WRITABLE, \
                      PyBuffer_Release
 
 
@@ -570,7 +571,7 @@ cdef class DatasetID(ObjectID):
                 if out is None:
                     data = <char *>emalloc(read_chunk_nbytes)
                 else:
-                    PyObject_GetBuffer(out, &view, PyBUF_ANY_CONTIGUOUS)
+                    PyObject_GetBuffer(out, &view, PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE)
                     if view.len < read_chunk_nbytes:
                         raise ValueError("out is not large enough (%d, require %d)" % (view.len, read_chunk_nbytes))
                     data = <char *>view.buf


### PR DESCRIPTION
A few cosmetic suggestions for `read_direct_chunk` update:
- Place the output buffer argument as last argument to keep compatibility of passing unnamed arguments
- Rename the `buffer=None` argument to `out=None` as done in `numpy`.
- Raise a `ValueError` exception when buffer is not big enough.